### PR TITLE
Update to Octave v8.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   DOCKER_USER: ${{secrets.DOCKER_USER}}
   DOCKER_TOKEN: ${{secrets.DOCKER_TOKEN}}
   REPO_NAME: ${{secrets.REPO_NAME}}
-  OCTAVE_VERSION: 6.4.0
+  OCTAVE_VERSION: 8.3.0
   DEBIAN_VERSION: 12.1
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,8 +34,8 @@ jobs:
         id: build_image
         run: |
           docker build \
-          --build-arg "OCTAVE_VERSION=${OCTAVE_VERSION} \
-          --build-arg "DEBIAN_VERSION=${DEBIAN_VERSION} \
+          --build-arg "OCTAVE_VERSION=${OCTAVE_VERSION}" \
+          --build-arg "DEBIAN_VERSION=${DEBIAN_VERSION}" \
           -f Dockerfile.${{matrix.image_version}} \
           -t ${DOCKER_USER}/$REPO_NAME:${{matrix.image_version}}-${OCTAVE_VERSION}-$GITHUB_SHA \
           .

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -157,6 +157,7 @@ RUN apt-get -qq -y update && \
     libwmf0.2-7 \
     libaec0 \
     libspqr2 \
+    libpcre3 \
     # Sundials
     libsundials-cvode6 \
     libsundials-ida6 \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -29,6 +29,8 @@ RUN apt-get -qq -y update && \
     libgl2ps-dev \
     libglpk-dev \
     libreadline-dev \
+    libspqr2 \
+    rapidjson-dev \
     gnuplot-x11 \
     # hdf5
     libhdf5-openmpi-dev \
@@ -154,6 +156,7 @@ RUN apt-get -qq -y update && \
     libwebpmux3 \
     libwmf0.2-7 \
     libaec0 \
+    libspqr2 \
     # Sundials
     libsundials-cvode6 \
     libsundials-ida6 \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,9 +1,11 @@
 ARG DEBIAN_VERSION=12.1
+ARG OCTAVE_VERSION=8.3.0
+
 FROM debian:${DEBIAN_VERSION}-slim as builder
+ARG OCTAVE_VERSION
 
 LABEL maintainer="Jonathan Goldfarb <jgoldfar@gmail.com>"
 
-ARG OCTAVE_VERSION=8.3.0
 # Make sure we don't get notifications we can't answer during building.
 ENV DEBIAN_FRONTEND=noninteractive \
     OctavePath=/opt/octave
@@ -93,6 +95,7 @@ RUN cd ${OctavePath} && \
 ##
 # https://packages.debian.org/search?suite=bookworm&section=all&arch=any&searchon=names&keywords=libgfortran
 FROM debian:${DEBIAN_VERSION}-slim as latest
+ARG OCTAVE_VERSION
 RUN apt-get -qq -y update && \
     apt-get -qq -y --no-install-recommends install \
     texinfo \
@@ -160,9 +163,6 @@ RUN apt-get -qq -y update && \
     # For Octave installation
     equivs
 
-
-# Set ENV the same as above
-ENV OCTAVE_VERSION=6.4.0
 
 # Copy over libs and share files
 COPY --from=builder /usr/local/lib/octave /usr/local/lib/octave

--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -171,6 +171,7 @@ RUN apt-get -qq -y update && \
     libwmf0.2-7 \
     libaec0 \
     libspqr2 \
+    libpcre3 \
     # QT
     libqscintilla2-qt5-15 \
     libqt5core5a \

--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -1,10 +1,11 @@
 # https://www.debian.org/releases/stable/ -> current LTS is Bookworm, 12.1
 ARG DEBIAN_VERSION=12.1
+ARG OCTAVE_VERSION=8.3.0
 FROM debian:${DEBIAN_VERSION}-slim as builder
+ARG OCTAVE_VERSION
 
 LABEL maintainer="Jonathan Goldfarb <jgoldfar@gmail.com>"
 
-ARG OCTAVE_VERSION=6.4.0
 # Make sure we don't get notifications we can't answer during building.
 ENV DEBIAN_FRONTEND=noninteractive \
     OctavePath=/opt/octave
@@ -106,6 +107,7 @@ RUN cd ${OctavePath} && \
 ##
 
 FROM debian:${DEBIAN_VERSION}-slim as gui
+ARG OCTAVE_VERSION
 RUN apt-get -qq -y update && \
     apt-get -qq -y --no-install-recommends install \
     texinfo \
@@ -186,8 +188,7 @@ RUN apt-get -qq -y update && \
 
 
 # Set ENV the same as above
-ENV OCTAVE_VERSION=6.4.0 \
-    DISPLAY=:0
+ENV DISPLAY=:0
 
 # Copy over libs and share files
 COPY --from=builder /usr/local/lib/octave /usr/local/lib/octave

--- a/Dockerfile.gui
+++ b/Dockerfile.gui
@@ -16,6 +16,7 @@ RUN apt-get -qq -y update && \
     g++ \
     gfortran \
     make \
+    rapidjson-dev \
     libblas-dev \
     liblapack-dev \
     libpcre3-dev \
@@ -31,6 +32,7 @@ RUN apt-get -qq -y update && \
     libglpk-dev \
     libreadline-dev \
     gnuplot-x11 \
+    libspqr2 \
     # hdf5
     libhdf5-openmpi-dev \
     openjdk-17-jdk \
@@ -168,6 +170,7 @@ RUN apt-get -qq -y update && \
     libwebpmux3 \
     libwmf0.2-7 \
     libaec0 \
+    libspqr2 \
     # QT
     libqscintilla2-qt5-15 \
     libqt5core5a \


### PR DESCRIPTION
Note: The version of Sundials on Debian Bookworm does not compile w/ Octave v6.4.0 (it assumes an older version)